### PR TITLE
Suppress regex warning on invalid escape sequence

### DIFF
--- a/proton/session/transports/utils/dns.py
+++ b/proton/session/transports/utils/dns.py
@@ -45,7 +45,7 @@ class DNSParser:
     #  - it has a minimum of 1 character and maximum of 63,
     #  - it only contains alphanumeric characters or the hyphen but
     #  - it does not start or end with a hyphen.
-    _VALID_HOSTNAME_SEGMENT = re.compile("(?!-)[A-Z\d-]{1,63}(?<!-)$", re.IGNORECASE)
+    _VALID_HOSTNAME_SEGMENT = re.compile(r"(?!-)[A-Z\d-]{1,63}(?<!-)$", re.IGNORECASE)
 
     # type definitions
     IPvxAddress = typing.Union[ipaddress.IPv4Address, ipaddress.IPv6Address]


### PR DESCRIPTION
This PR fixes the regex for `_is_valid_hostname`. A string passed to re.compile should be a raw string. Other regexes in protonvpn code do this correctly.

the current error is `dns.py:48: SyntaxWarning: invalid escape sequence '\d'`

[NO_TRAIN]::